### PR TITLE
Log0 fix + not using zstop

### DIFF
--- a/src/leafsep.cpp
+++ b/src/leafsep.cpp
@@ -91,7 +91,12 @@ void gmmByCluster(std::vector<pcl::PointCloud<PointTreeseg>::Ptr> &clouds, arma:
 		e2 = eigenvalues(1) / esum;
 		e3 = eigenvalues(0) / esum;
 		//UGLY:
-		if(e3 == 0) e3 = e2 * 0.01;
+		if (e1 == 0)
+			e1 = 0.001;
+		if (e2 == 0)
+			e2 = 0.001;
+		if (e3 == 0)
+			e3 = 0.001;
 		//
 		features[0] = e3;
 		features[1] = e1 - e2;

--- a/src/treeseg.cpp
+++ b/src/treeseg.cpp
@@ -682,7 +682,7 @@ void correctStem(pcl::PointCloud<PointTreeseg>::Ptr &stem, float nnearest, float
 			break;
 		}
 	}
-	if(broken == false) spatial1DFilter(stem,"z",min[2],zstop,corrected);
+	if(broken == true) spatial1DFilter(stem,"z",min[2],zstop,corrected);
 	else spatial1DFilter(stem,"z",min[2],max[2]-zstep,corrected);
 }
 


### PR DESCRIPTION
Potentially any two e's can be zero, not just e3.
I was getting 1,0,0 which was causing an error.