### PR TITLE
fix: initialize cylinder variables

### DIFF
--- a/src/treeseg.cpp
+++ b/src/treeseg.cpp
@@ -508,6 +508,11 @@ void fitCylinder(pcl::PointCloud<PointTreeseg>::Ptr &cloud, int nnearest, bool f
 			cyl.dy = coeff.values[4];
 			cyl.dz = coeff.values[5];
 			cyl.rad = coeff.values[6];
+			
+			cyl.steprad = 0;//init these to zero as we are not always setting in these in cylinderDiagnostics
+			cyl.stepcov = 0;
+			cyl.radratio = 0;
+			
 			cyl.cloud = cloud;
 			cyl.inliers = inliers;
 			if(cyl.rad > 0 && finite == false && diagnostics == false) cyl.ismodel = true;


### PR DESCRIPTION
In fit cylinder -> cylinder diagnostics, during findstems:
```c
if(zrads.size() >= NSTEP - 2)
```
is false then 
```c
cyl.steprad
cyl.stepcov
cyl.radratio
```
are never initialized.

This leads to cylinders that fail the above if statement, to usually contain the values for the previous cylinder. this results in the addition of stray clusters in the stem cloud.

below is a diagnostic output of each cylinder during findstems, notice the persistent values.

cylinder | ismodel: | rad: | len: | stepcov: | radratio: | coords:
-- | -- | -- | -- | -- | -- | --
85 | 0 | -0.06115 | 1.15648 | 0.079674 | 0.760223 | 0
86 | 1 | 0.232121 | 1.01388 | 0.079674 | 0.760223 | 1
87 | 1 | 0.246831 | 1.32824 | 0.079674 | 0.760223 | 0
88 | 1 | 0.17803 | 1.3648 | 0.079674 | 0.760223 | 0
89 | 1 | 0.161701 | 1.23133 | 0.079674 | 0.760223 | 0
90 | 0 | -0.21989 | 1.23133 | 0.079674 | 0.760223 | 0
91 | 1 | 0.416498 | 2.22029 | 0.381345 | 0.349013 | 1
92 | 0 | -0.23312 | 2.22029 | 0.381345 | 0.349013 | 1
93 | 1 | 0.172219 | 0.543981 | 0.381345 | 0.349013 | 1
94 | 1 | 3.12624 | 1.61311 | 0.381345 | 0.349013 | 1
95 | 1 | 0.130281 | 1.17716 | 0.047319 | 0.835921 | 1



