### PR TITLE
Pre-calculated kdtree

### DIFF
--- a/include/treeseg.h
+++ b/include/treeseg.h
@@ -32,6 +32,7 @@
 #include <pcl/point_cloud.h>
 #include <pcl/PointIndices.h>
 
+#include <pcl/kdtree/kdtree_flann.h>
 struct treeparams
 {
 	float x,y;
@@ -62,6 +63,7 @@ std::vector<float> dNN(pcl::PointCloud<PointTreeseg>::Ptr &cloud, int nnearest);
 std::vector<std::vector<float>> dNNz(pcl::PointCloud<PointTreeseg>::Ptr &cloud, int nnearest, float zstep);
 std::vector<int> nearestIdx(pcl::PointCloud<PointTreeseg>::Ptr &searchpoints, pcl::PointCloud<PointTreeseg>::Ptr &cloud);
 
+float minDistBetweenClouds(pcl::PointCloud<PointTreeseg>::Ptr &a, pcl::PointCloud<PointTreeseg>::Ptr &b, pcl::KdTreeFLANN<PointTreeseg> &kdtree);
 float minDistBetweenClouds(pcl::PointCloud<PointTreeseg>::Ptr &a, pcl::PointCloud<PointTreeseg>::Ptr &b);
 
 void downsample(pcl::PointCloud<PointTreeseg>::Ptr &original, float edgelength, pcl::PointCloud<PointTreeseg>::Ptr &filtered);

--- a/src/treeseg.cpp
+++ b/src/treeseg.cpp
@@ -184,10 +184,15 @@ std::vector<std::vector<int>> nNearestIdx(pcl::PointCloud<PointTreeseg>::Ptr &cl
 
 float minDistBetweenClouds(pcl::PointCloud<PointTreeseg>::Ptr &a, pcl::PointCloud<PointTreeseg>::Ptr &b)
 {
-	//assuming a is the larger of the two clouds
-	float distance = std::numeric_limits<float>::infinity();
 	pcl::KdTreeFLANN<PointTreeseg> kdtree;
 	kdtree.setInputCloud(a);
+	return minDistBetweenClouds(a,b,kdtree);
+}
+
+float minDistBetweenClouds(pcl::PointCloud<PointTreeseg>::Ptr &a, pcl::PointCloud<PointTreeseg>::Ptr &b, pcl::KdTreeFLANN<PointTreeseg> &kdtree)
+{
+	//assuming a is the larger of the two clouds
+	float distance = std::numeric_limits<float>::infinity();
 	int K = 1;
 	for(pcl::PointCloud<PointTreeseg>::iterator it=b->begin();it!=b->end();it++)
 	{

--- a/src/treeseg.cpp
+++ b/src/treeseg.cpp
@@ -851,6 +851,7 @@ void buildTree(std::vector<pcl::PointCloud<PointTreeseg>::Ptr> &clusters, pcl::P
 
 	std::vector<Eigen::Vector4f> clustermins; // all cluster centroids
 	std::vector<Eigen::Vector4f> clustermaxs; // all cluster centroids
+	std::vector<pcl::KdTreeFLANN<PointTreeseg>> kdtrees; // all cluster kdtrees
 
 	std::vector<int> clusteridxs; // indexs of unused clusters
 
@@ -878,11 +879,15 @@ void buildTree(std::vector<pcl::PointCloud<PointTreeseg>::Ptr> &clusters, pcl::P
 
 		Eigen::Vector4f clustervector(clustereigenvectors(0, 2), clustereigenvectors(1, 2), clustereigenvectors(2, 2), 0);
 
+		pcl::KdTreeFLANN<PointTreeseg> tree;
+		tree.setInputCloud(clusters[i]);
+
 		clusterlengths.push_back(clusterlength);
 		clustervectors.push_back(clustervector);
 		clustercentroids.push_back(clustercentroid);
 		clustermins.push_back(clustermin);
 		clustermaxs.push_back(clustermax);
+		kdtrees.push_back(tree);
 
 		clusteridxs.push_back(i);
 	}
@@ -920,9 +925,9 @@ void buildTree(std::vector<pcl::PointCloud<PointTreeseg>::Ptr> &clusters, pcl::P
 						// if bounding boxes are closer than mind then do min distance check
 						float d;
 						if (clusters[outeridxs[i]]->points.size() >= clusters[clusteridxs[j]]->points.size())
-							d = minDistBetweenClouds(clusters[outeridxs[i]], clusters[clusteridxs[j]]); // this takes the most time so we want to minimize this check by doing it last
+							d = minDistBetweenClouds(clusters[outeridxs[i]], clusters[clusteridxs[j]],kdtrees[outeridxs[i]]); // this takes the most time so we want to minimize this check by doing it last
 						else
-							d = minDistBetweenClouds(clusters[clusteridxs[j]], clusters[outeridxs[i]]);
+							d = minDistBetweenClouds(clusters[clusteridxs[j]], clusters[outeridxs[i]]),kdtrees[clusteridxs[j]];
 						if (d <= mind)
 						{
 							member.push_back(j); // save j for adding


### PR DESCRIPTION
Much faster tree building for large trees at the cost of some RAM.

for pictured tree

> original single threaded: 116 minutes
> new single threaded: 21 minutes.

In the case of some trees, which have a many points in a single cluster, and that cluster has a large bounding box. (see attached image)
We get a very large outer cloud and hundreds of inner clouds that each must have the min_distance calculated.

In the original implementation the kdtree for the larger cloud is calculated for each comparison.
This pull request pre-computes the kdtrees (along with the other cluster parameters).

This results in significantly faster buildtree times for trees of a similar nature.

potential downsides are:
- some clusters may never need the kdtree calculated.
 my testing seems to show that the extra overhead is fairly minimal.
 this has potential to be worked on at the cost of code complexity and readability.
- higher ram usage: 533 vs 396 Mb for the below tree

![image](https://user-images.githubusercontent.com/26135231/83603801-66791c00-a5b8-11ea-8f16-e92fedb1defa.png)
