### PR TITLE
fix make error: split is not a member of boost

### DIFF
--- a/src/pcdPointTreeseg2txt.cpp
+++ b/src/pcdPointTreeseg2txt.cpp
@@ -1,6 +1,7 @@
 #include "treeseg.h"
 
 #include <pcl/io/pcd_io.h>
+#include <boost/algorithm/string.hpp>
 
 int main (int argc, char **argv)
 {

--- a/src/pcdPointXYZRGB2txt.cpp
+++ b/src/pcdPointXYZRGB2txt.cpp
@@ -1,4 +1,5 @@
 #include <pcl/io/pcd_io.h>
+#include <boost/algorithm/string.hpp>
 
 int main (int argc, char **argv)
 {

--- a/src/treeseg.cpp
+++ b/src/treeseg.cpp
@@ -39,6 +39,7 @@
 #include <pcl/segmentation/region_growing.h>
 #include <pcl/segmentation/sac_segmentation.h>
 #include <pcl/octree/octree.h>
+#include <boost/algorithm/string.hpp>
 
 //File IO
 

--- a/src/txtPointTreeseg2pcd.cpp
+++ b/src/txtPointTreeseg2pcd.cpp
@@ -1,6 +1,7 @@
 #include "treeseg.h"
 
 #include <pcl/io/pcd_io.h>
+#include <boost/algorithm/string.hpp>
 
 int main (int argc, char **argv)
 {


### PR DESCRIPTION
compiling gave error: split is not a member of boost
fix: added "#include <boost/algorithm/string.hpp>" to four files

ubuntu 22.04