### PR TITLE
Fix "'split' is not a member of 'boost'" error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ treeseg has been developed and tested on Ubuntu 20.04 LTS only, and is dependent
 These dependencies are installed via apt:
 
 ```
+apt-get update;
+apt-get install -y git cmake;
 apt install libpcl-dev libarmadillo-dev
 ```
 

--- a/src/pcdPointTreeseg2txt.cpp
+++ b/src/pcdPointTreeseg2txt.cpp
@@ -1,5 +1,5 @@
 #include "treeseg.h"
-
+#include <boost/algorithm/string.hpp>
 #include <pcl/io/pcd_io.h>
 
 int main (int argc, char **argv)

--- a/src/pcdPointXYZRGB2txt.cpp
+++ b/src/pcdPointXYZRGB2txt.cpp
@@ -1,4 +1,5 @@
 #include <pcl/io/pcd_io.h>
+#include <boost/algorithm/string.hpp>
 
 int main (int argc, char **argv)
 {

--- a/src/treeseg.cpp
+++ b/src/treeseg.cpp
@@ -39,6 +39,7 @@
 #include <pcl/segmentation/region_growing.h>
 #include <pcl/segmentation/sac_segmentation.h>
 #include <pcl/octree/octree.h>
+#include <boost/algorithm/string.hpp>
 
 //File IO
 

--- a/src/txtPointTreeseg2pcd.cpp
+++ b/src/txtPointTreeseg2pcd.cpp
@@ -1,6 +1,7 @@
 #include "treeseg.h"
 
 #include <pcl/io/pcd_io.h>
+#include <boost/algorithm/string.hpp>
 
 int main (int argc, char **argv)
 {


### PR DESCRIPTION
I'm using Ubuntu 24.04, and encountered error: `'split' is not a member of 'boost' `during the `make` process, which may be an error for users not using Ubuntu 20.04. 
I solved by adding `#include <boost/algorithm/string.hpp>` in some files, according to a [comment ](https://github.com/apburt/treeseg/issues/46#issuecomment-2285671451) under issue https://github.com/apburt/treeseg/issues/46. I also added the command line to install `cmake` based on issue https://github.com/apburt/treeseg/issues/1.
